### PR TITLE
Change inflection library to jinzhu/inflection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 _obj
 _test
 
+# Editors
+.idea
+
 # Architecture specific extensions/prefixes
 *.[568vq]
 [568vq].out

--- a/yml2sql/yml2sql.go
+++ b/yml2sql/yml2sql.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strings"
 
-	"bitbucket.org/pkg/inflect"
+	"github.com/jinzhu/inflection"
 	"gopkg.in/yaml.v2"
 )
 
@@ -88,7 +88,7 @@ func getTableName(path string) string {
 	}
 	// add 's' when plural flag is set
 	if isPlural() {
-		return inflect.Pluralize(name)
+		return inflection.Plural(name)
 	}
 	return name
 }


### PR DESCRIPTION
`bitbucket.org/pkg/inflect`がBitBucketから消えてgo modのproxyになさそうなので、以下のライブラリへの差し替えをしてみました。
https://github.com/jinzhu/inflection

go modの対応をついでにしたかったんですが、別レポジトリからinitしたらおかしくなっていたため一旦諦めました。